### PR TITLE
Fixing typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -377,7 +377,7 @@ pylava_wow.py:
                     return [{
                         lnum: 0,
                         col: 0,
-                        text: 'Wow has been finded.',
+                        text: 'Wow has been found.',
                         type: 'WOW'
                     }]
 


### PR DESCRIPTION
`finded` in the code example for custom linters is gramatically incorrect. Changed this to `found`.